### PR TITLE
Allowing Type option in settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function initialize() {
                         titleField: types[i].title,
                         dateField: types[i].dateField,
                         mainContent: types[i].mainContent,
+                        type: types[i].type
                     };
                     // check file extension settings
                     switch (contentSettings.fileExtension) {
@@ -83,6 +84,7 @@ function initialize() {
                         dateField: single.dateField,
                         mainContent: single.mainContent,
                         isSingle: true,
+                        type: single.type
                     };
                     switch (contentSettings.fileExtension) {
                         case 'md':
@@ -155,6 +157,9 @@ function getContentType(limit, skip, contentSettings, itemsPulled) {
                 if (contentSettings.isHeadless) {
                     frontMatter.headless = true;
                     mkdirp.sync(`.${contentSettings.directory + item.sys.id}`);
+                }
+                if (contentSettings.type) {
+                    frontMatter.type = contentSettings.type
                 }
                 frontMatter.updated = item.sys.updatedAt;
                 frontMatter.createdAt = item.sys.createdAt;

--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,7 @@ repeatableTypes:
 | fileExtension | optional                         | can be "md", "yml", or "yaml" (defaults to "md")                                                                                                     |
 | isHeadless    | optional (repeatable types only) | turns all entries in a content type into headless leaf bundles (see [hugo docs](https://gohugo.io/content-management/page-bundles/#headless-bundle)) |
 | mainContent   | optional                         | field ID for field you want to be the main Markdown content. (Does not work with rich text fields)                                                   |
+| type          | optional                        | Allows a type to be set enabling a different layout to be used (see [hugo docs](https://gohugo.io/content-management/types/))|
 
 # Expected Output
 

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ repeatableTypes:
 | fileExtension | optional                         | can be "md", "yml", or "yaml" (defaults to "md")                                                                                                     |
 | isHeadless    | optional (repeatable types only) | turns all entries in a content type into headless leaf bundles (see [hugo docs](https://gohugo.io/content-management/page-bundles/#headless-bundle)) |
 | mainContent   | optional                         | field ID for field you want to be the main Markdown content. (Does not work with rich text fields)                                                   |
-| type          | optional                        | Allows a type to be set enabling a different layout to be used (see [hugo docs](https://gohugo.io/content-management/types/))|
+| type          | optional                         | Allows a type to be set enabling a different layout to be used (see [hugo docs](https://gohugo.io/content-management/types/))|
 
 # Expected Output
 

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ repeatableTypes:
 | fileExtension | optional                         | can be "md", "yml", or "yaml" (defaults to "md")                                                                                                     |
 | isHeadless    | optional (repeatable types only) | turns all entries in a content type into headless leaf bundles (see [hugo docs](https://gohugo.io/content-management/page-bundles/#headless-bundle)) |
 | mainContent   | optional                         | field ID for field you want to be the main Markdown content. (Does not work with rich text fields)                                                   |
-| type          | optional                         | Allows a type to be set enabling a different layout to be used (see [hugo docs](https://gohugo.io/content-management/types/))|
+| type          | optional                         | Allows a type to be set enabling a different layout to be used (see [hugo docs](https://gohugo.io/content-management/types/))                        |
 
 # Expected Output
 


### PR DESCRIPTION
Hey,

I wanted the ability to be able to have content served from the root but use a different layout.

Setting a type option seemed like the best option so I quickly wrote it in. Hopefully it's useful for you too. It's especially useful for repeatable types that you want to hardcode the type in.

I've also updated the readme to reflect this change.

Cheers!