### PR TITLE
Adding variable file names and basic rich text to markdown rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data
 .env
 contentful-settings.yaml
 resources
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -52,13 +52,8 @@ function initialize() {
                         dateField: types[i].dateField,
                         mainContent: types[i].mainContent,
                         fileNameField: types[i].fileNameField,
-                        includeFrontMatter: types[i].includeFrontMatter,
                     };
-                    // Include front matter by default
-                    console.log("includeFrontMatter", contentSettings.includeFrontMatter)
-                    if (contentSettings.includeFrontMatter === undefined) {
-                        contentSettings.includeFrontMatter = true;
-                    }
+
                     // check file extension settings
                     switch (contentSettings.fileExtension) {
                         case 'md':
@@ -153,135 +148,135 @@ function getContentType(limit, skip, contentSettings, itemsPulled) {
                 let item = data.items[i];
                 let fileContent = '';
 
-                if (contentSettings.includeFrontMatter) {
-                    let frontMatter = {};
-                    if (
-                        contentSettings.fileExtension === 'md' ||
-                        contentSettings.fileExtension == null ||
-                        contentSettings.fileExtension == undefined
-                    ) {
-                        fileContent += `---\n`;
-                    }
-                    if (contentSettings.isHeadless) {
-                        frontMatter.headless = true;
-                        mkdirp.sync(`.${contentSettings.directory + item.sys.id}`);
-                    }
-                    frontMatter.updated = item.sys.updatedAt;
-                    frontMatter.createdAt = item.sys.createdAt;
-                    frontMatter.date = item.sys.createdAt;
-                    for (let field of Object.keys(item.fields)) {
-                        if (field === contentSettings.mainContent || field === contentSettings.fileNameField) {
-                            // skips to prevent duplicating mainContent or fileNameField in frontmatter
-                            continue;
-                        } else if(field === 'date') {
-                            // convert dates with time to ISO String so Hugo can properly Parse
-                            let d = item.fields[field]
-                            if(d.length > 10) {
-                                frontMatter.date = new Date(d).toISOString()
-                            } else {
-                                frontMatter.date = d
-                            }
-                            continue;
+
+                let frontMatter = {};
+                if (
+                    contentSettings.fileExtension === 'md' ||
+                    contentSettings.fileExtension == null ||
+                    contentSettings.fileExtension == undefined
+                ) {
+                    fileContent += `---\n`;
+                }
+                if (contentSettings.isHeadless) {
+                    frontMatter.headless = true;
+                    mkdirp.sync(`.${contentSettings.directory + item.sys.id}`);
+                }
+                frontMatter.updated = item.sys.updatedAt;
+                frontMatter.createdAt = item.sys.createdAt;
+                frontMatter.date = item.sys.createdAt;
+                for (let field of Object.keys(item.fields)) {
+                    if (field === contentSettings.mainContent || field === contentSettings.fileNameField) {
+                        // skips to prevent duplicating mainContent or fileNameField in frontmatter
+                        continue;
+                    } else if(field === 'date') {
+                        // convert dates with time to ISO String so Hugo can properly Parse
+                        let d = item.fields[field]
+                        if(d.length > 10) {
+                            frontMatter.date = new Date(d).toISOString()
+                        } else {
+                            frontMatter.date = d
                         }
-                        let fieldContent = item.fields[field];
-                        switch (typeof fieldContent) {
-                            case 'object':
-                                if ('sys' in fieldContent) {
-                                    frontMatter[field] = {};
-                                    switch (fieldContent.sys.type) {
-                                        case 'Asset':
-                                            frontMatter[field] = getAssetFields(
-                                                fieldContent
-                                            );
-                                            break;
-                                        case 'Entry':
-                                            frontMatter[field] = getEntryFields(
-                                                fieldContent
-                                            );
-                                            break;
-                                        default:
-                                            frontMatter[field] = fieldContent;
-                                            break;
-                                    }
-                                }
-                                // rich text (see rich text function)
-                                else if ('nodeType' in fieldContent) {
-                                    frontMatter[field] = [];
-                                    frontMatter[
-                                        `${field}_plaintext`
-                                    ] = richTextToPlain(fieldContent);
-                                    let nodes = fieldContent.content;
-                                    for (let i = 0; i < nodes.length; i++) {
-                                        frontMatter[field].push(
-                                            richTextNodes(nodes[i])
+                        continue;
+                    }
+                    let fieldContent = item.fields[field];
+                    switch (typeof fieldContent) {
+                        case 'object':
+                            if ('sys' in fieldContent) {
+                                frontMatter[field] = {};
+                                switch (fieldContent.sys.type) {
+                                    case 'Asset':
+                                        frontMatter[field] = getAssetFields(
+                                            fieldContent
                                         );
-                                    }
-                                }
-                                // arrays
-                                else {
-                                    if (!fieldContent.length) {
+                                        break;
+                                    case 'Entry':
+                                        frontMatter[field] = getEntryFields(
+                                            fieldContent
+                                        );
+                                        break;
+                                    default:
                                         frontMatter[field] = fieldContent;
-                                    } else {
-                                        frontMatter[field] = [];
-                                        for (
-                                            let i = 0;
-                                            i < fieldContent.length;
-                                            i++
-                                        ) {
-                                            let arrayNode = fieldContent[i];
-                                            switch (typeof arrayNode) {
-                                                case 'object':
-                                                    let arrayObject = {};
-                                                    switch (arrayNode.sys.type) {
-                                                        case 'Asset':
-                                                            arrayObject = getAssetFields(
-                                                                arrayNode
-                                                            );
-                                                            frontMatter[field].push(
-                                                                arrayObject
-                                                            );
-                                                            break;
-                                                        case 'Entry':
-                                                            arrayObject = getEntryFields(
-                                                                arrayNode
-                                                            );
-                                                            frontMatter[field].push(
-                                                                arrayObject
-                                                            );
-                                                            break;
-                                                        default:
-                                                            frontMatter[field].push(
-                                                                arrayNode
-                                                            );
-                                                            break;
-                                                    }
-                                                    break;
-                                                default:
-                                                    frontMatter[field].push(
-                                                        arrayNode
-                                                    );
-                                                    break;
-                                            }
+                                        break;
+                                }
+                            }
+                            // rich text (see rich text function)
+                            else if ('nodeType' in fieldContent) {
+                                frontMatter[field] = [];
+                                frontMatter[
+                                    `${field}_plaintext`
+                                ] = richTextToPlain(fieldContent);
+                                let nodes = fieldContent.content;
+                                for (let i = 0; i < nodes.length; i++) {
+                                    frontMatter[field].push(
+                                        richTextNodes(nodes[i])
+                                    );
+                                }
+                            }
+                            // arrays
+                            else {
+                                if (!fieldContent.length) {
+                                    frontMatter[field] = fieldContent;
+                                } else {
+                                    frontMatter[field] = [];
+                                    for (
+                                        let i = 0;
+                                        i < fieldContent.length;
+                                        i++
+                                    ) {
+                                        let arrayNode = fieldContent[i];
+                                        switch (typeof arrayNode) {
+                                            case 'object':
+                                                let arrayObject = {};
+                                                switch (arrayNode.sys.type) {
+                                                    case 'Asset':
+                                                        arrayObject = getAssetFields(
+                                                            arrayNode
+                                                        );
+                                                        frontMatter[field].push(
+                                                            arrayObject
+                                                        );
+                                                        break;
+                                                    case 'Entry':
+                                                        arrayObject = getEntryFields(
+                                                            arrayNode
+                                                        );
+                                                        frontMatter[field].push(
+                                                            arrayObject
+                                                        );
+                                                        break;
+                                                    default:
+                                                        frontMatter[field].push(
+                                                            arrayNode
+                                                        );
+                                                        break;
+                                                }
+                                                break;
+                                            default:
+                                                frontMatter[field].push(
+                                                    arrayNode
+                                                );
+                                                break;
                                         }
                                     }
                                 }
-                                break;
-                            default:
-                                frontMatter[field] = item.fields[field];
-                                break;
-                        }
-                    }
-
-
-                    // add current item to filecontent
-                    fileContent += YAML.stringify(frontMatter);
-                    if (
-                        contentSettings.fileExtension != 'yaml' ||
-                        contentSettings.fileExtension != 'yml'
-                    ) {
-                        fileContent += `---\n`;
+                            }
+                            break;
+                        default:
+                            frontMatter[field] = item.fields[field];
+                            break;
                     }
                 }
+
+
+                // add current item to filecontent
+                fileContent += YAML.stringify(frontMatter);
+                if (
+                    contentSettings.fileExtension != 'yaml' ||
+                    contentSettings.fileExtension != 'yml'
+                ) {
+                    fileContent += `---\n`;
+                }
+                
 
                 // if set add the main content below the front matter
                 if (item.fields[contentSettings.mainContent]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "contentful-hugo",
-  "version": "1.3.12",
+  "name": "@chris.sears/contentful-hugo",
+  "version": "1.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "contentful-hugo",
-  "version": "1.3.12",
+  "name": "@chris.sears/contentful-hugo",
+  "version": "1.3.13",
   "description": "Node module that pulls data from Contentful and turns it into markdown files for Hugo. Can be used with other Static Site Generators, but has some Hugo specific features.",
   "main": "index.js",
   "repository": {
     "typ": "git",
-    "url": "https://github.com/ModiiMedia/contentful-hugo"
+    "url": "git+https://github.com/ModiiMedia/contentful-hugo.git"
   },
   "keywords": [
     "hugo",
@@ -20,11 +20,7 @@
     "frontmatter",
     "static-site"
   ],
-  "author": {
-    "name": "Joshua Sosso",
-    "email": "josh@modiimedia.com",
-    "url": "https://www.modiimedia.com"
-  },
+  "author": "Joshua Sosso <josh@modiimedia.com> (https://www.modiimedia.com)",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -46,5 +42,12 @@
     "readme.md",
     "index.js",
     "src"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/ModiiMedia/contentful-hugo/issues"
+  },
+  "homepage": "https://github.com/ModiiMedia/contentful-hugo#readme",
+  "directories": {
+    "example": "examples"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chris.sears/contentful-hugo",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Node module that pulls data from Contentful and turns it into markdown files for Hugo. Can be used with other Static Site Generators, but has some Hugo specific features.",
   "main": "index.js",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,6 @@ repeatableTypes:
       fileExtension: md
       mainContent: body
       fileNameField: slug
-      includeFrontMatter: false
 
     - id: seoFields
       isHeadless: true
@@ -165,7 +164,6 @@ repeatableTypes:
 | isHeadless         | optional (repeatable types only) | turns all entries in a content type into headless leaf bundles (see [hugo docs](https://gohugo.io/content-management/page-bundles/#headless-bundle)) |
 | mainContent        | optional                         | field ID for field you want to be the main Markdown content. (Does not work with rich text fields)                                                   |
 | fileNameField      | optional (repeatable types only) | generated files will be named after the value of this field                                                                                          |
-| includeFrontMatter | optional (repeatable types only) | if set to 'false' markdown file content will only include the main content                                                                           |
 
 # Expected Output
 

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,15 @@ repeatableTypes:
       fileExtension: md
       mainContent: content
 
+    # generates markdown files named after the value of 'slug' field, 
+    # with just the main content field as the contents of each file
+    - id: pages
+      directory: /content/
+      fileExtension: md
+      mainContent: body
+      fileNameField: slug
+      includeFrontMatter: false
+
     - id: seoFields
       isHeadless: true
       directory: /content/seo-fields/
@@ -147,14 +156,16 @@ repeatableTypes:
 
 **Configuration Options**
 
-| field         | required                         | description                                                                                                                                          |
-| ------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| id            | required                         | contentful content type ID goes here                                                                                                                 |
-| directory     | required                         | directory where you want the file(s) to be generated (leading and trailing slashes required for the time being)                                      |
-| fileName      | required (single types only)     | name of the file generated                                                                                                                           |
-| fileExtension | optional                         | can be "md", "yml", or "yaml" (defaults to "md")                                                                                                     |
-| isHeadless    | optional (repeatable types only) | turns all entries in a content type into headless leaf bundles (see [hugo docs](https://gohugo.io/content-management/page-bundles/#headless-bundle)) |
-| mainContent   | optional                         | field ID for field you want to be the main Markdown content. (Does not work with rich text fields)                                                   |
+| field              | required                         | description                                                                                                                                          |
+| ------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id                 | required                         | contentful content type ID goes here                                                                                                                 |
+| directory          | required                         | directory where you want the file(s) to be generated (leading and trailing slashes required for the time being)                                      |
+| fileName           | required (single types only)     | name of the file generated                                                                                                                           |
+| fileExtension      | optional                         | can be "md", "yml", or "yaml" (defaults to "md")                                                                                                     |
+| isHeadless         | optional (repeatable types only) | turns all entries in a content type into headless leaf bundles (see [hugo docs](https://gohugo.io/content-management/page-bundles/#headless-bundle)) |
+| mainContent        | optional                         | field ID for field you want to be the main Markdown content. (Does not work with rich text fields)                                                   |
+| fileNameField      | optional (repeatable types only) | generated files will be named after the value of this field                                                                                          |
+| includeFrontMatter | optional (repeatable types only) | if set to 'false' markdown file content will only include the main content                                                                           |
 
 # Expected Output
 

--- a/src/richTextToMarkdown.js
+++ b/src/richTextToMarkdown.js
@@ -10,10 +10,10 @@ function rtListToMarkdown(nodes, listMode) {
     return markdown
 }
 
-function rtArrayToMarkdown(nodes) {
+function rtArrayToMarkdown(nodes, listMode=null, listIndex=0) {
     markdown = ""
     for (node of nodes){
-        markdown += richTextToMarkdown(node)
+        markdown += richTextToMarkdown(node, listMode, listIndex)
     }
     return markdown
 }
@@ -27,36 +27,38 @@ function richTextToMarkdown(node, listMode=null, listIndex=0) {
         marks = marks.map(x => x.type);
     }
     data = node['data'];
-    console.log(nodeType)
     switch (nodeType) {
         case 'text':
             preMarks = "";
             postMarks = "";
             if (marks.indexOf('underline') >= 0) {
-                preMarks = "++" + preMarks;
-                postMarks = postMarks + "++";
+                preMarks = "<u>" + preMarks;
+                postMarks = postMarks + "</u>";
             }
             if (marks.indexOf('bold') >= 0) {
                 preMarks = "**" + preMarks;
-                postMarks = postMarks + "**";
+                postMarks = postMarks + "** ";
             }
             if (marks.indexOf('italic') >= 0) {
                 preMarks = "_" + preMarks;
-                postMarks = postMarks + "_";
+                postMarks = postMarks + "_ ";
             }
             if (marks.indexOf('code') >= 0) {
                 preMarks = "`" + preMarks;
                 postMarks = postMarks + "`";
             }
             if (node['value']) {
-                markdown += preMarks + node['value'] + postMarks;
+                markdown += preMarks + node['value'].trim() + postMarks;
             }
             break;
         case 'paragraph':
-            markdown += rtArrayToMarkdown(content) + "\n";
+            if (listMode === null) {
+                markdown += "\n";
+            }
+            markdown += rtArrayToMarkdown(content, listMode, listIndex) + "\n";
             break;
         case 'blockquote':
-            markdown += "\n > " + rtArrayToMarkdown(content);
+            markdown += "\n> " + rtArrayToMarkdown(content, 'blockquote');
             break;
         case 'heading-1':
             markdown += "\n# " + rtArrayToMarkdown(content) + "\n";
@@ -77,23 +79,24 @@ function richTextToMarkdown(node, listMode=null, listIndex=0) {
             // not yet implemented
             break;
         case 'hyperlink':
-            markdown += "[" + rtArrayToMarkdown(content) + "](" + data.uri + ")";
+            uri = data.uri
+            markdown += "[" + rtArrayToMarkdown(content) + "](" + uri + ") ";
             break;
         case 'hr':
-            markdown += "\n---\n";
+            markdown += "\n---\n\n";
             break;
         case 'list-item':
             if (listMode === 'ordered') {
-                markdown += " " + listIndex + ". " + rtArrayToMarkdown(content);
+                markdown += " " + listIndex + ". " + rtArrayToMarkdown(content, listMode, listIndex);
             } else {
-                markdown += " - " + rtArrayToMarkdown(content);
+                markdown += " - " + rtArrayToMarkdown(content, listMode, listIndex);
             }
             break;
         case 'unordered-list':
-            markdown += rtListToMarkdown(content, 'unordered');
+            markdown += "\n" + rtListToMarkdown(content, 'unordered');
             break;
         case 'ordered-list':
-            markdown += rtListToMarkdown(content, 'ordered');
+            markdown += "\n" + rtListToMarkdown(content, 'ordered');
             break;
         case 'embedded-asset-block':
             // not yet implemented

--- a/src/richTextToMarkdown.js
+++ b/src/richTextToMarkdown.js
@@ -1,0 +1,108 @@
+// Converts Contentful rich text to Hugo-flavored markdown
+
+function rtListToMarkdown(nodes, listMode) {
+    markdown = ""
+    listIndex = 0
+    for (node of nodes){
+        listIndex += 1
+        markdown += richTextToMarkdown(node, listMode, listIndex)
+    }
+    return markdown
+}
+
+function rtArrayToMarkdown(nodes) {
+    markdown = ""
+    for (node of nodes){
+        markdown += richTextToMarkdown(node)
+    }
+    return markdown
+}
+
+function richTextToMarkdown(node, listMode=null, listIndex=0) {
+    markdown = "";
+    nodeType = node['nodeType'];
+    content = node['content'];
+    marks = node['marks']
+    if (marks) {
+        marks = marks.map(x => x.type);
+    }
+    data = node['data'];
+    console.log(nodeType)
+    switch (nodeType) {
+        case 'text':
+            preMarks = "";
+            postMarks = "";
+            if (marks.indexOf('underline') >= 0) {
+                preMarks = "++" + preMarks;
+                postMarks = postMarks + "++";
+            }
+            if (marks.indexOf('bold') >= 0) {
+                preMarks = "**" + preMarks;
+                postMarks = postMarks + "**";
+            }
+            if (marks.indexOf('italic') >= 0) {
+                preMarks = "_" + preMarks;
+                postMarks = postMarks + "_";
+            }
+            if (marks.indexOf('code') >= 0) {
+                preMarks = "`" + preMarks;
+                postMarks = postMarks + "`";
+            }
+            if (node['value']) {
+                markdown += preMarks + node['value'] + postMarks;
+            }
+            break;
+        case 'paragraph':
+            markdown += rtArrayToMarkdown(content) + "\n";
+            break;
+        case 'blockquote':
+            markdown += "\n > " + rtArrayToMarkdown(content);
+            break;
+        case 'heading-1':
+            markdown += "\n# " + rtArrayToMarkdown(content) + "\n";
+            break;
+        case 'heading-2':
+            markdown += "\n## " + rtArrayToMarkdown(content) + "\n";
+            break;
+        case 'heading-3':
+            markdown += "\n### " + rtArrayToMarkdown(content) + "\n";
+            break;
+        case 'heading-4':
+            markdown += "\n#### " + rtArrayToMarkdown(content) + "\n";
+            break;
+        case 'heading-5':
+            markdown += "\n##### " + rtArrayToMarkdown(content) + "\n";
+            break;
+        case 'entry-hyperlink':
+            // not yet implemented
+            break;
+        case 'hyperlink':
+            markdown += "[" + rtArrayToMarkdown(content) + "](" + data.uri + ")";
+            break;
+        case 'hr':
+            markdown += "\n---\n";
+            break;
+        case 'list-item':
+            if (listMode === 'ordered') {
+                markdown += " " + listIndex + ". " + rtArrayToMarkdown(content);
+            } else {
+                markdown += " - " + rtArrayToMarkdown(content);
+            }
+            break;
+        case 'unordered-list':
+            markdown += rtListToMarkdown(content, 'unordered');
+            break;
+        case 'ordered-list':
+            markdown += rtListToMarkdown(content, 'ordered');
+            break;
+        case 'embedded-asset-block':
+            // not yet implemented
+            break;
+        case 'document':
+            markdown += rtArrayToMarkdown(content);
+            break;
+    }
+    return markdown;
+}
+
+module.exports = richTextToMarkdown;


### PR DESCRIPTION
I added two minor features, which I can split into different PRs if you prefer.

The first is a contentSetting config field called `fileNameField`, which allows for the filename to be dynamically specified by a field in Contentful, instead of using the Entry ID.

The second is a basic markdown render function for rich text fields.

I updated the readme with usage info.