### PR TITLE
Add Support For Contentful Preview API

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const contentful = require('contentful');
 const yaml = require('js-yaml');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
+const argv = require('yargs').argv;
 const richTextToPlain = require('@contentful/rich-text-plain-text-renderer')
 	.documentToPlainTextString;
 

--- a/index.js
+++ b/index.js
@@ -18,11 +18,14 @@ require('dotenv').config();
 let totalContentTypes = 0;
 let typesExtracted = 0;
 
-if (process.env.CONTENTFUL_SPACE && process.env.CONTENTFUL_TOKEN) {
+if (
+	process.env.CONTENTFUL_SPACE &&
+	(process.env.CONTENTFUL_TOKEN || process.env.CONTENTFUL_PREVIEW_TOKEN)
+) {
 	initialize();
 } else {
 	console.log(
-		`\nERROR: Environment variables not yet set.\n\nThis module requires the following environmental variables to be set before running:\nCONTENTFUL_SPACE, CONTENTFUL_TOKEN\n\nYou can set them using the command line or place them in a .env file.\n`
+		`\nERROR: Environment variables not yet set.\n\nThis module requires the following environmental variables to be set before running:\nCONTENTFUL_SPACE, CONTENTFUL_TOKEN, CONTENTFUL_PREVIEW_TOKEN (optional)\n\nYou can set them using the command line or place them in a .env file.\n`
 	);
 }
 
@@ -115,10 +118,12 @@ function initialize() {
 /// get content for a single content type ///
 // itemsPulled refers to entries that have already been called it's used in conjunction with skip for pagination
 function getContentType(limit, skip, contentSettings, itemsPulled) {
-	const client = contentful.createClient({
+	const options = {
 		space: process.env.CONTENTFUL_SPACE,
-		accessToken: process.env.CONTENTFUL_TOKEN,
-	});
+		host: argv.preview ? 'preview.contentful.com' : 'cdn.contentful.com',
+		accessToken: argv.preview ? process.env.CONTENTFUL_PREVIEW_TOKEN : process.env.CONTENTFUL_TOKEN
+	};
+	const client = contentful.createClient(options);
 
 	// check for file extension default to markdown
 	if (!contentSettings.fileExtension) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@ const contentful = require('contentful');
 const yaml = require('js-yaml');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
-const argv = require('yargs').argv;
+const yargs = require('yargs');
+yargs.options({
+	preview: { type: 'boolean', default: false, alias: 'P' },
+});
+const argv = yargs.argv;
 const richTextToPlain = require('@contentful/rich-text-plain-text-renderer')
 	.documentToPlainTextString;
 
@@ -13,7 +17,6 @@ const createFile = require('./src/createFile');
 const checkIfFinished = require('./src/checkIfFinished');
 
 require('dotenv').config();
-
 // counter variables
 let totalContentTypes = 0;
 let typesExtracted = 0;
@@ -33,9 +36,10 @@ if (
 function initialize() {
 	const configFile = 'contentful-settings.yaml';
 	// check if configFile exist and throw error if it doesn't
+	let deliveryMode = argv.preview ? 'Preview Data' : 'Published Data';
 	if (fs.existsSync(configFile)) {
 		console.log(
-			`\n-------------------------------------\n   Pulling Data from Contentful...\n-------------------------------------\n`
+			`\n---------------------------------------------\n   Pulling ${deliveryMode} from Contentful...\n---------------------------------------------\n`
 		);
 		try {
 			const config = yaml.safeLoad(
@@ -121,7 +125,7 @@ function initialize() {
 // itemsPulled refers to entries that have already been called it's used in conjunction with skip for pagination
 function getContentType(limit, skip, contentSettings, itemsPulled) {
 	let previewMode = false;
-	if (argv.preview || argv.P) {
+	if (argv.preview) {
 		previewMode = true;
 	}
 	if (previewMode && !process.env.CONTENTFUL_PREVIEW_TOKEN) {
@@ -421,7 +425,9 @@ function getContentType(limit, skip, contentSettings, itemsPulled) {
 				);
 				typesExtracted++;
 				if (checkIfFinished(typesExtracted, totalContentTypes)) {
-					console.log(`\n-------------------------------------\n`);
+					console.log(
+						`\n---------------------------------------------\n`
+					);
 				}
 			}
 		})

--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function initialize() {
 							console.log(
 								`   ERROR: extension "${contentSettings.fileExtension}" not supported`
 							);
+							break;
 					}
 				}
 			}
@@ -102,6 +103,7 @@ function initialize() {
 							console.log(
 								`   ERROR: extension "${contentSettings.fileExtension}" not supported`
 							);
+							break;
 					}
 				}
 			}
@@ -118,10 +120,23 @@ function initialize() {
 /// get content for a single content type ///
 // itemsPulled refers to entries that have already been called it's used in conjunction with skip for pagination
 function getContentType(limit, skip, contentSettings, itemsPulled) {
+	let previewMode = false;
+	if (argv.preview || argv.P) {
+		previewMode = true;
+	}
+	if (previewMode && !process.env.CONTENTFUL_PREVIEW_TOKEN) {
+		throw new Error(
+			'Environment variable CONTENTFUL_PREVIEW_TOKEN not set'
+		);
+	} else if (!previewMode && !process.env.CONTENTFUL_TOKEN) {
+		throw new Error('Environment variable CONTENTFUL_TOKEN not set');
+	}
 	const options = {
 		space: process.env.CONTENTFUL_SPACE,
-		host: argv.preview ? 'preview.contentful.com' : 'cdn.contentful.com',
-		accessToken: argv.preview ? process.env.CONTENTFUL_PREVIEW_TOKEN : process.env.CONTENTFUL_TOKEN
+		host: previewMode ? 'preview.contentful.com' : 'cdn.contentful.com',
+		accessToken: previewMode
+			? process.env.CONTENTFUL_PREVIEW_TOKEN
+			: process.env.CONTENTFUL_TOKEN,
 	};
 	const client = contentful.createClient(options);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,11 @@
 			"resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-13.4.0.tgz",
 			"integrity": "sha512-YPdYqGmWiGAood7ri2BUXfPQKNthkQYV1rmQdaq4UAxWK5NLB5NXckaUYLbohqhHKtrq4tnfzVn+ePWID7Dzbg=="
 		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
 		"acorn": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
@@ -73,8 +78,7 @@
 		"ansi-regex": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-			"dev": true
+			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -140,6 +144,11 @@
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
 		},
+		"camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -171,6 +180,26 @@
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
 			"dev": true
+		},
+		"cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"requires": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
 		},
 		"color-convert": {
 			"version": "1.9.3",
@@ -257,6 +286,11 @@
 				"ms": "2.0.0"
 			}
 		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -289,8 +323,7 @@
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -717,6 +750,11 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+		},
 		"get-stdin": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -888,8 +926,7 @@
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 		},
 		"is-glob": {
 			"version": "4.0.1",
@@ -1303,6 +1340,16 @@
 			"resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.7.tgz",
 			"integrity": "sha512-wjM17CJ2kk0SgoGyJ7ZMzRRCuTq+V8YhMwpZ5XEWX0uaked2OUq6utvHXGNBQrfkUzUUABFMyxlKn+85hMv4dg=="
 		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+		},
 		"resolve": {
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
@@ -1366,6 +1413,11 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"shebang-command": {
 			"version": "1.2.0",
@@ -1448,7 +1500,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
 			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -1459,7 +1510,6 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
 					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
 					}
@@ -1637,11 +1687,58 @@
 				"isexe": "^2.0.0"
 			}
 		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+					"integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
@@ -1656,6 +1753,83 @@
 			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1"
+			}
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+		},
+		"yargs": {
+			"version": "15.0.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.0.2.tgz",
+			"integrity": "sha512-GH/X/hYt+x5hOat4LMnCqMd8r5Cv78heOMIJn1hr7QPPBqfeC6p89Y78+WB9yGDvfpCvgasfmWLzNzEioOUD9Q==",
+			"requires": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^16.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+			"integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+			"requires": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"dotenv": "^7.0.0",
 		"js-yaml": "^3.13.1",
 		"json-to-pretty-yaml": "^1.2.2",
-		"mkdirp": "^0.5.1"
+		"mkdirp": "^0.5.1",
+		"yargs": "^15.0.2"
 	},
 	"bin": {
 		"contentful-hugo": "./cli.js"

--- a/readme.md
+++ b/readme.md
@@ -51,10 +51,14 @@ npx contentful-hugo
 
 ### Optional Flags
 
-```txt
-flags:
+| flag      | aliases | description                                                                              |
+| --------- | ------- | ---------------------------------------------------------------------------------------- |
+| --preview | -P      | runs in preview mode, which pulls both published and unpublished entries from Contentful |
 
-  -P,  --preview          runs in preview mode, which pulls both published and unpublished entries from Contentful
+#### Preview Mode Example
+
+```powershell
+contentful-hugo --preview
 ```
 
 ### Example Package.json

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Contentful Hugo
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/281eacf31e864217953437f66b7e3a72)](https://www.codacy.com/app/joshmossas/contentful-hugo?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ModiiMedia/contentful-hugo&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/281eacf31e864217953437f66b7e3a72)](https://www.codacy.com/app/joshmossas/contentful-hugo?utm_source=github.com&utm_medium=referral&utm_content=ModiiMedia/contentful-hugo&utm_campaign=Badge_Grade)
 
 This is a simple Node.js CLI tool that pulls data from Contentful CMS and turns it into Markdown or YAML files for use with a static site generator. It can be used with any static site generator that uses Markdown with YAML frontmatter, but it has some features that are specific to [Hugo](https://gohugo.io).
 
@@ -49,6 +49,12 @@ contentful-hugo
 npx contentful-hugo
 ```
 
+### Optional Flags
+
+| flag | description |
+|------|-------------|
+| --preview |  runs in preview mode, which pulls both published and unpublished entries from Contentful |
+
 ### Example Package.json
 
 ```JSON
@@ -77,13 +83,16 @@ Trying to use this package before completing configuration will return an error 
 
 ### Environment Variables
 
-Before using you must first set the following environment variables. CONTENTFUL_SPACE, and CONTENTFUL_TOKEN.
+Before using you must first set the following environment variables. CONTENTFUL_SPACE, and CONTENTFUL_TOKEN. You can also add the CONTENTFUL_PREVIEW_TOKEN variable to use the --preview flag.
 
 This can be done with a **.env** file in the root directory of your project.
 
 ```TOML
-CONTENTFUL_SPACE = '<your-space-id>'
-CONTENTFUL_TOKEN = '<content-api-access-token>'
+CONTENTFUL_SPACE = '<space-id>'
+CONTENTFUL_TOKEN = '<content-accessToken>'
+
+# optional but required for preview mode
+CONTENTFUL_PREVIEW_TOKEN = '<preview-accessToken>'
 ```
 
 You can also declare the environment variables in the command line
@@ -93,13 +102,15 @@ You can also declare the environment variables in the command line
 ```powershell
 $env:CONTENTFUL_SPACE="<contentful_space_id>"
 $env:CONTENTFUL_TOKEN="<contentful_acessToken>"
+$env:CONTENTFUL_PREVIEW_TOKEN="<contentful_preview_accessToken>"
 ```
 
 **Bash:**
 
 ```bash
-export CONTENTFUL_SPACE=<contentful_space_id>
-export CONTENTFUL_TOKEN=<contentful_acessToken>
+export CONTENTFUL_SPACE="<contentful_space_id>"
+export CONTENTFUL_TOKEN="<contentful_accessToken>"
+export CONTENTFUL_PREVIEW_TOKEN="<contentful_preview_accessToken>"
 ```
 
 ### Config File
@@ -189,8 +200,8 @@ If you're using Hugo you can access the information like below:
 
 ```html
 <img
-    src="{{ .Params.assetFieldName.url }}"
-    width="{{ .Params.assetFieldName.width }}"
+	src="{{ .Params.assetFieldName.url }}"
+	width="{{ .Params.assetFieldName.width }}"
 />
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -51,9 +51,11 @@ npx contentful-hugo
 
 ### Optional Flags
 
-| flag | description |
-|------|-------------|
-| --preview |  runs in preview mode, which pulls both published and unpublished entries from Contentful |
+```txt
+flags:
+
+  -P,  --preview          runs in preview mode, which pulls both published and unpublished entries from Contentful
+```
 
 ### Example Package.json
 


### PR DESCRIPTION
Adds the following features:

- CONTENTFUL_PREVIEW_TOKEN environment variable
- CLI flag `--preview` to run contentful-hugo in preview mode
- `-P` is a shorter alias for `--preview`
- throws error when running in preview mode without setting CONTENTFUL_PREVIEW_TOKEN
- Documentation indicating how to run contentful-hugo in preview mode
- Updated log messages indicating when running in default vs preview mode