### PR TITLE
Leading and trailing spaces check

### DIFF
--- a/examples/rich-text-example/content/posts/3q8HKIHFAPbdS8orkzwSuK.md
+++ b/examples/rich-text-example/content/posts/3q8HKIHFAPbdS8orkzwSuK.md
@@ -1,6 +1,6 @@
 ---
 type: "blog"
-updated: "2020-09-15T02:04:03.953Z"
+updated: "2020-11-06T00:00:58.363Z"
 createdAt: "2019-08-23T21:34:33.719Z"
 date: "2019-08-23T21:34:33.719Z"
 title: "Example With Text, Assets, and Entries"
@@ -22,7 +22,7 @@ tags:
   - "entries"
 ---
 
-In this example we will see a bit of everything. Below me is an embedded asset.
+In this example we will see a bit of everything. Below me is an embedded    ***asset***    .
 
 {{< contentful-hugo/embedded-asset title="Man in Red Shirt" description="Man in red shirt excited because he was able to use port his rich text fields over to Hugo." url="//images.ctfassets.net/6fc4s4k6v9co/4up9JEFDVOMp1zLOqbAbRN/0054a3bbfc0c5cf4ae172c6957b5b42c/photo-1533227268428-f9ed0900fb3b" filename="photo-1533227268428-f9ed0900fb3b" assetType="image/jpeg" size="470466" width="1779" height="1539" parentContentType="post" >}}
 

--- a/examples/rich-text-example/content/posts/3q8HKIHFAPbdS8orkzwSuK.md
+++ b/examples/rich-text-example/content/posts/3q8HKIHFAPbdS8orkzwSuK.md
@@ -1,6 +1,6 @@
 ---
 type: "blog"
-updated: "2020-11-06T00:00:58.363Z"
+updated: "2020-11-06T00:02:16.430Z"
 createdAt: "2019-08-23T21:34:33.719Z"
 date: "2019-08-23T21:34:33.719Z"
 title: "Example With Text, Assets, and Entries"
@@ -22,7 +22,7 @@ tags:
   - "entries"
 ---
 
-In this example we will see a bit of everything. Below me is an embedded    ***asset***    .
+In this example we will see a bit of everything. Below me is an embedded<u>    ***asset***   </u> .
 
 {{< contentful-hugo/embedded-asset title="Man in Red Shirt" description="Man in red shirt excited because he was able to use port his rich text fields over to Hugo." url="//images.ctfassets.net/6fc4s4k6v9co/4up9JEFDVOMp1zLOqbAbRN/0054a3bbfc0c5cf4ae172c6957b5b42c/photo-1533227268428-f9ed0900fb3b" filename="photo-1533227268428-f9ed0900fb3b" assetType="image/jpeg" size="470466" width="1779" height="1539" parentContentType="post" >}}
 

--- a/src/helpers/strings.test.ts
+++ b/src/helpers/strings.test.ts
@@ -2,6 +2,8 @@ const {
     replaceSpecialEntities,
     isMultilineString,
     removeLeadingAndTrailingSlashes,
+    leadingSpaces,
+    trailingSpaces,
 } = require('./strings');
 
 describe('Detect Multiline String', () => {
@@ -81,5 +83,70 @@ describe('file path', () => {
         expect(
             removeLeadingAndTrailingSlashes('//content/posts/something//')
         ).toBe('content/posts/something');
+    });
+});
+
+describe('Leading Spaces', () => {
+    test('One Leading Space', () => {
+        const str = ' johnathon slayter';
+        const spaces = leadingSpaces(str);
+        expect(spaces.exists).toBe(true);
+        expect(spaces.count).toBe(1);
+        expect(spaces.newString).toBe('johnathon slayter');
+    });
+    test('No Leading Spaces', () => {
+        const str = 'john doe smith  ';
+        const spaces = leadingSpaces(str);
+        expect(spaces.exists).toBe(false);
+        expect(spaces.count).toBe(0);
+        expect(spaces.newString).toBe('john doe smith  ');
+    });
+    test('Four Leading Spaces', () => {
+        const str = '    john doe';
+        const spaces = leadingSpaces(str);
+        expect(spaces.exists).toBe(true);
+        expect(spaces.count).toBe(4);
+        expect(spaces.newString).toBe('john doe');
+    });
+    test('Markdown Rendering Test', () => {
+        const str = '  john smith';
+        const spaces = leadingSpaces(str);
+        const newString = `${spaces.removedSpaces}**${spaces.newString}**`;
+        expect(newString).toBe('  **john smith**');
+    });
+});
+
+describe('Trailing Spaces', () => {
+    test('One Trailing Space', () => {
+        const str = 'johnathon slayter ';
+        const spaces = trailingSpaces(str);
+        expect(spaces.exists).toBe(true);
+        expect(spaces.count).toBe(1);
+        expect(spaces.newString).toBe('johnathon slayter');
+    });
+    test('No Trailing Spaces', () => {
+        const str = '  john doe smith';
+        const spaces = trailingSpaces(str);
+        expect(spaces.exists).toBe(false);
+        expect(spaces.count).toBe(0);
+        expect(spaces.newString).toBe('  john doe smith');
+    });
+    test('Four Trailing Spaces', () => {
+        const str = 'john doe    ';
+        const spaces = trailingSpaces(str);
+        expect(spaces.exists).toBe(true);
+        expect(spaces.count).toBe(4);
+        expect(spaces.newString).toBe('john doe');
+    });
+});
+
+describe('Markdown Rendering', () => {
+    test('Input with leading and trailing spaces', () => {
+        const input = '  john smith ';
+        const expectedValue = '  **john smith** ';
+        const leading = leadingSpaces(input);
+        const trailing = trailingSpaces(leading.newString);
+        const result = `${leading.removedSpaces}**${trailing.newString}**${trailing.removedSpaces}`;
+        expect(result).toBe(expectedValue);
     });
 });

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -33,9 +33,53 @@ const replaceSpecialEntities = (string: string): string => {
     return finalString;
 };
 
+interface StringSpaceCleanupObject {
+    exists: boolean;
+    newString: string;
+    removedSpaces: string;
+    count: number;
+}
+
+const leadingSpaces = (string: string, count = 0): StringSpaceCleanupObject => {
+    if (string.charAt(0) === ' ') {
+        return leadingSpaces(string.slice(1), count + 1);
+    }
+    let removedSpaces = '';
+    for (let i = 0; i < count; i++) {
+        removedSpaces += ' ';
+    }
+    return {
+        exists: count > 0,
+        newString: string,
+        removedSpaces,
+        count,
+    };
+};
+
+const trailingSpaces = (
+    string: string,
+    count = 0
+): StringSpaceCleanupObject => {
+    if (string.charAt(string.length - 1) === ' ') {
+        return trailingSpaces(string.slice(0, -1), count + 1);
+    }
+    let removedSpaces = '';
+    for (let i = 0; i < count; i++) {
+        removedSpaces += ' ';
+    }
+    return {
+        exists: count > 0,
+        newString: string,
+        removedSpaces,
+        count,
+    };
+};
+
 export {
     isMultilineString,
     replaceSpecialEntities,
     specialEntities,
     removeLeadingAndTrailingSlashes,
+    leadingSpaces,
+    trailingSpaces,
 };

--- a/src/main/src/processEntry/src/richTextToMarkdown.test.ts
+++ b/src/main/src/processEntry/src/richTextToMarkdown.test.ts
@@ -148,6 +148,17 @@ describe('Marks', () => {
             `\n**bold text example**\n\n`
         );
     });
+    test('Bold With Extra Spaces', () => {
+        const node = contentNodeFactory(
+            'paragraph',
+            '    bold text example  ',
+            [{ type: 'bold' }]
+        );
+        const richText = richTextFactory([node]);
+        expect(richTextToMarkdown(richText)).toBe(
+            `\n    **bold text example**  \n\n`
+        );
+    });
     test('Underline', () => {
         const node = contentNodeFactory(
             'paragraph',
@@ -166,6 +177,17 @@ describe('Marks', () => {
         const richText = richTextFactory([node]);
         expect(richTextToMarkdown(richText)).toBe(
             `\n*italic text example*\n\n`
+        );
+    });
+    test('Italic with Extra Spaces', () => {
+        const node = contentNodeFactory(
+            'paragraph',
+            '      italic text example   ',
+            [{ type: 'italic' }]
+        );
+        const richText = richTextFactory([node]);
+        expect(richTextToMarkdown(richText)).toBe(
+            `\n      *italic text example*   \n\n`
         );
     });
     test('Code (Single-Line)', () => {

--- a/src/main/src/processEntry/src/richTextToMarkdown.ts
+++ b/src/main/src/processEntry/src/richTextToMarkdown.ts
@@ -21,7 +21,12 @@ import {
     documentToHtmlString,
     Next,
 } from '@contentful/rich-text-html-renderer';
-import { isMultilineString, replaceSpecialEntities } from '@helpers/strings';
+import {
+    isMultilineString,
+    replaceSpecialEntities,
+    leadingSpaces,
+    trailingSpaces,
+} from '@helpers/strings';
 import { Entry, Asset } from 'contentful';
 import { AssetObject } from './getAssetFields';
 
@@ -173,14 +178,23 @@ const optionsRenderNode = (parentContentType = ''): any => {
     };
 };
 
+const sanitizedMarkOutput = (
+    input: string,
+    markWrapper: '**' | '*'
+): string => {
+    const leading = leadingSpaces(input);
+    const trailing = trailingSpaces(leading.newString);
+    return `${leading.removedSpaces}${markWrapper}${trailing.newString}${markWrapper}${trailing.removedSpaces}`;
+};
+
 const options = (parentContentType = '') => {
     return {
         renderMark: {
             [MARKS.BOLD]: (text: string) => {
-                return `**${text}**`;
+                return sanitizedMarkOutput(text, '**');
             },
             [MARKS.ITALIC]: (text: string) => {
-                return `*${text}*`;
+                return sanitizedMarkOutput(text, '*');
             },
             [MARKS.CODE]: (text: string) => {
                 if (isMultilineString(text)) {


### PR DESCRIPTION
Fix for issue mentioned at https://github.com/ModiiMedia/contentful-hugo/issues/27

With this change we now check for leading spaces and trailing spaces before rendering marks. If there are leading or trailing spaces they get move to being outside of the markdown wrapper (```**``` for bold and ```*``` for italic) to preserve spacing without messing up the markdown rendering.