### PR TITLE
New Feature: Field overrides

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ content
 *.test.ts
 dist
 coverage
+*.html

--- a/readme.md
+++ b/readme.md
@@ -312,6 +312,7 @@ repeatableTypes:
 | mainContent    | optional | Field ID for field you want to be the main Markdown content. (Can be a markdown, richtext, or string field)                   |
 | type           | optional | Manually set value for "type" field in the frontmatter (see [hugo docs](https://gohugo.io/content-management/types/))         |
 | resolveEntries | optional | Resolve the specified reference fields and/or asset fields to one of it's properties specified with the `resolveTo` parameter |
+| overrides      | optional | Do custom overrides for field values or field names                                                                           |
 
 ##### <u>**Repeatable Type Options**</u>
 
@@ -325,8 +326,11 @@ repeatableTypes:
 | mainContent               | optional | Field ID for field you want to be the main markdown content. (Can be a markdown, richtext, or string field)                                                                                                                                |
 | type                      | optional | Manually set value for "type" field in the frontmatter (see [hugo docs](https://gohugo.io/content-management/types/))                                                                                                                      |
 | resolveEntries            | optional | Resolve the specified reference fields and/or asset fields to one of it's properties specified with the `resolveTo` parameter                                                                                                              |
+| overrides                 | optional | Do custom overrides for field values or field names                                                                                                                                                                                        |
 
-#### Advanced Config Example
+#### Advanced Config Examples
+
+##### Dynmically Changing Tokens
 
 Here is an example of dynamically change the `token`, `previewToken`, and `environment` options depending on any arbitrary condition.
 
@@ -352,6 +356,42 @@ module.exports = {
     },
     // rest of config
 };
+```
+
+##### Overriding Fields and Field Values
+
+```js
+// contentful-hugo.config.js
+
+module.exports = {
+    repeatableTypes: [
+        {
+            id: "trips",
+            directory: "content/trips"
+            overrides: [{
+                field: "url",
+                options: {
+                    // change the url field name to "slug" in frontmatter
+                    fieldName: "slug"
+                }
+            },
+            {
+                field: "distanceInKilometers",
+                options: {
+                    // rename "distanceInKilometers" to "distanceInMiles"
+                    fieldName: "distanceInMiles",
+                    // convert distance to miles and output the result in frontmatter
+                    valueTransformer: (val) => {
+                        if(typeof val === 'number') {
+                            return val * 0.621371
+                        }
+                        return 0
+                    }
+                }
+            }]
+        }
+    ]
+}
 ```
 
 #### Config File Autocomplete

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,8 @@
 import { loadConfig, ContentfulConfig } from './src/config';
-import { ConfigContentfulSettings } from './src/config/src/types';
+import {
+    ConfigContentfulSettings,
+    OverrideConfig,
+} from './src/config/src/types';
 import getContentType from './src/getContentType';
 import getContentTypeResultMessage from './src/getContentTypeResultMessage';
 import initializeDirectory from './src/initializeDirectory';
@@ -26,6 +29,7 @@ export interface ContentSettings {
     isTaxonomy?: boolean;
     type?: string;
     resolveEntries?: { field: string; resolveTo: string }[];
+    overrides?: OverrideConfig[];
 }
 
 interface ContentfulError {
@@ -147,6 +151,7 @@ const fetchDataFromContentful = async (
                 type,
                 isTaxonomy,
                 resolveEntries,
+                overrides,
             } = types[i];
             const contentSettings: ContentSettings = {
                 typeId: id,
@@ -159,6 +164,7 @@ const fetchDataFromContentful = async (
                 type: type,
                 isTaxonomy,
                 resolveEntries,
+                overrides,
             };
             // check file extension settings
             switch (fileExtension) {
@@ -200,6 +206,7 @@ const fetchDataFromContentful = async (
                 mainContent,
                 resolveEntries,
                 type,
+                overrides,
             } = single;
             const contentSettings: ContentSettings = {
                 typeId: id,
@@ -212,6 +219,7 @@ const fetchDataFromContentful = async (
                 isSingle: true,
                 type: type,
                 resolveEntries,
+                overrides,
             };
             switch (contentSettings.fileExtension) {
                 case 'md':

--- a/src/main/src/config/src/types.ts
+++ b/src/main/src/config/src/types.ts
@@ -9,9 +9,9 @@ export interface OverrideConfig {
         /**
          * Overrides the fieldname
          */
-        name?: string;
+        fieldName?: string;
         /**
-         * Transforms the value of the field
+         * Transforms the value of the field.
          */
         valueTransformer?: (fieldValue: unknown) => unknown;
     };

--- a/src/main/src/config/src/types.ts
+++ b/src/main/src/config/src/types.ts
@@ -3,6 +3,20 @@ export interface ResolveEntryConfig {
     resolveTo: string;
 }
 
+export interface OverrideConfig {
+    field: string;
+    options: {
+        /**
+         * Overrides the fieldname
+         */
+        name?: string;
+        /**
+         * Transforms the value of the field
+         */
+        valueTransformer?: (fieldValue: unknown) => unknown;
+    };
+}
+
 export interface TypeConfig {
     /**
      * Contentful content type ID
@@ -21,9 +35,13 @@ export interface TypeConfig {
     mainContent?: string;
     fileExtension?: string;
     /**
-     * Configs specifying how to resolve asset references and entry references
+     * Options specifying how to resolve asset references and entry references
      */
     resolveEntries?: ResolveEntryConfig[];
+    /**
+     * Options that allow you to override field names and modify field values before rendering the content file
+     */
+    overrides?: OverrideConfig[];
 }
 
 export interface SingleTypeConfig extends TypeConfig {

--- a/src/main/src/processEntry/index.ts
+++ b/src/main/src/processEntry/index.ts
@@ -12,6 +12,7 @@ const processEntry = (
         type,
         mainContent,
         resolveEntries,
+        overrides,
     } = contentSettings;
     const frontMatter = mapFields(
         item,
@@ -19,7 +20,8 @@ const processEntry = (
         isHeadless,
         type,
         mainContent,
-        resolveEntries
+        resolveEntries,
+        overrides
     );
     const content = contentSettings.mainContent
         ? getMainContent(item, contentSettings.mainContent)

--- a/src/main/src/processEntry/mapper.ts
+++ b/src/main/src/processEntry/mapper.ts
@@ -148,8 +148,8 @@ const mapFields = (
         const fieldContent = entry.fields[field];
         let fieldName = field;
         const fieldOverride = shouldOverride(field, overrides);
-        if (fieldOverride && fieldOverride.options?.name) {
-            fieldName = fieldOverride.options.name;
+        if (fieldOverride && fieldOverride.options?.fieldName) {
+            fieldName = fieldOverride.options.fieldName;
         }
         if (fieldOverride && fieldOverride.options?.valueTransformer) {
             frontMatter[fieldName] = fieldOverride.options.valueTransformer(

--- a/src/main/src/processEntry/mapper.ts
+++ b/src/main/src/processEntry/mapper.ts
@@ -6,6 +6,7 @@ import getEntryFields from './src/getEntryFields';
 import getAssetFields from './src/getAssetFields';
 import richTextToMarkdown from './src/richTextToMarkdown';
 import richTextNodes from './src/richTextNodes';
+import { OverrideConfig } from '../config/src/types';
 
 const mapArrayField = (
     fieldContent: Entry<any>[] | Asset[] | string[]
@@ -83,6 +84,18 @@ const shouldResolve = (
     return false;
 };
 
+const shouldOverride = (
+    fieldName: string,
+    overrides: OverrideConfig[] = []
+) => {
+    for (const item of overrides) {
+        if (fieldName === item.field) {
+            return item;
+        }
+    }
+    return false;
+};
+
 const resolveEntry = (entry: any = {}, resolvesToString = ''): any => {
     const props = resolvesToString.split('.');
     let value = entry;
@@ -118,9 +131,10 @@ const mapFields = (
     isHeadless?: boolean,
     type?: string,
     mainContentField?: string,
-    resolveList?: ResolveEntryConfig[]
+    resolveList?: ResolveEntryConfig[],
+    overrides?: OverrideConfig[]
 ): any => {
-    const frontMatter: any = {};
+    const frontMatter: { [key: string]: any } = {};
     if (isHeadless) {
         frontMatter.headless = true;
     }
@@ -132,14 +146,26 @@ const mapFields = (
     frontMatter.date = entry.sys.createdAt;
     for (const field of Object.keys(entry.fields)) {
         const fieldContent = entry.fields[field];
+        let fieldName = field;
+        const fieldOverride = shouldOverride(field, overrides);
+        if (fieldOverride && fieldOverride.options?.name) {
+            fieldName = fieldOverride.options.name;
+        }
+        if (fieldOverride && fieldOverride.options?.valueTransformer) {
+            frontMatter[fieldName] = fieldOverride.options.valueTransformer(
+                entry.fields[field]
+            );
+            continue;
+        }
         const fieldResolver = shouldResolve(field, resolveList);
         if (fieldResolver) {
-            frontMatter[field] = resolveField(
+            frontMatter[fieldName] = resolveField(
                 fieldContent,
                 fieldResolver.resolveTo
             );
             continue;
         }
+
         if (field === mainContentField) {
             // skips to prevent duplicating mainContent in frontmatter
             continue;
@@ -156,11 +182,11 @@ const mapFields = (
         switch (typeof fieldContent) {
             case 'object':
                 if ('sys' in fieldContent) {
-                    frontMatter[field] = mapReferenceField(fieldContent);
+                    frontMatter[fieldName] = mapReferenceField(fieldContent);
                 }
                 // rich text (see rich text function)
                 else if ('nodeType' in fieldContent) {
-                    frontMatter[field] = mapRichTextField(
+                    frontMatter[fieldName] = mapRichTextField(
                         fieldContent
                     ).richText;
                     frontMatter[`${field}_plaintext`] = mapRichTextField(
@@ -169,11 +195,11 @@ const mapFields = (
                 }
                 // arrays
                 else {
-                    frontMatter[field] = mapArrayField(fieldContent);
+                    frontMatter[fieldName] = mapArrayField(fieldContent);
                 }
                 break;
             default:
-                frontMatter[field] = fieldContent;
+                frontMatter[fieldName] = fieldContent;
                 break;
         }
     }

--- a/src/main/src/processEntry/mapper.ts
+++ b/src/main/src/processEntry/mapper.ts
@@ -84,10 +84,10 @@ const shouldResolve = (
     return false;
 };
 
-const shouldOverride = (
+export const shouldOverride = (
     fieldName: string,
     overrides: OverrideConfig[] = []
-) => {
+): OverrideConfig | false => {
     for (const item of overrides) {
         if (fieldName === item.field) {
             return item;


### PR DESCRIPTION
Adds a feature allowing devs to override the value or the name of specific fields. 

Usage:

```js
// in config for specific content type
overrides: [
  {
    field: 'someField',
    options: {
        fieldName: 'someReplacementFieldName',
        valueTransformer: (value) => {
             // do something with value
             return value
        }
  }
]
```