### PR TITLE
[New Feature] Static content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 /content
+/static_content
 data
 /.temp
 /layouts

--- a/package-lock.json
+++ b/package-lock.json
@@ -2150,8 +2150,6 @@
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
             "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-            "dev": true,
-            "optional": true,
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -2164,11 +2162,9 @@
             },
             "dependencies": {
                 "anymatch": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-                    "dev": true,
-                    "optional": true,
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+                    "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
                     "requires": {
                         "normalize-path": "^3.0.0",
                         "picomatch": "^2.0.4"
@@ -2177,16 +2173,12 @@
                 "binary-extensions": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-                    "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-                    "dev": true,
-                    "optional": true
+                    "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
                 },
                 "braces": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
                     "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "fill-range": "^7.0.1"
                     }
@@ -2195,8 +2187,6 @@
                     "version": "7.0.1",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
                     "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "to-regex-range": "^5.0.1"
                     }
@@ -2205,8 +2195,6 @@
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "is-glob": "^4.0.1"
                     }
@@ -2215,8 +2203,6 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
                     "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "binary-extensions": "^2.0.0"
                     }
@@ -2224,16 +2210,12 @@
                 "is-number": {
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-                    "dev": true,
-                    "optional": true
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
                 },
                 "readdirp": {
                     "version": "3.5.0",
                     "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
                     "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "picomatch": "^2.2.1"
                     }
@@ -2242,8 +2224,6 @@
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
                     "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "is-number": "^7.0.0"
                     }
@@ -3830,7 +3810,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "optional": true
         },
         "function-bind": {
@@ -4314,8 +4293,7 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -4332,7 +4310,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -6658,8 +6635,7 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "npm-run-path": {
             "version": "4.0.1",
@@ -6955,8 +6931,7 @@
         "picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-            "dev": true
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
         },
         "pify": {
             "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@contentful/rich-text-plain-text-renderer": "^14.1.2",
         "@contentful/rich-text-types": "^14.1.2",
         "async-limiter": "^2.0.0",
+        "chokidar": "^3.5.1",
         "contentful": "^8.2.1",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,7 @@ npx contentful-hugo [flags]
 | --config  | -C      | Specify the path to a config file.                                                                       |
 | --server  | -S      | Run in server mode to recieve webhooks from Contentful (BETA)                                            |
 | --port    |         | Specify port for server mode (Default 1414)                                                              |
+| --clean   |         | Delete any directories specified in singleTypes and repeatableTypes                                      |
 | --help    |         | Show help                                                                                                |
 | --version |         | Show version number                                                                                      |
 
@@ -251,6 +252,13 @@ module.exports = {
             isTaxonomy: true, // Experimental Feature
         },
     ],
+
+    staticContent: [
+        {
+            inputDir: 'static_content',
+            ouputDir: 'content',
+        },
+    ],
 };
 ```
 
@@ -359,7 +367,7 @@ repeatableTypes:
 | filters                   | optional | Accepts an object of Contentful search parameters to filter results. See [Contentful docs](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/select-operator)                       |
 | ignoreLocales             | optional | Ignore localization settings and only pull from the default locale (defaults to false)                                                                                                                                                     |
 
-#### <u>**Localization Options**</u>
+##### <u>**Localization Options**</u>
 
 The config also has a `locales` field that allows you to specify what locales you want to pull from. This field can take an array of strings, an array of objects, or a combination.
 
@@ -412,7 +420,7 @@ After configuring locales in Contentful Hugo you will need to update your Hugo c
     #language settings
 ```
 
-##### Locale Specific Directories
+###### Locale Specific Directories
 
 There are sometimes cases where you will want to place content in a directory based on it's locale rather than using a file extension based translation. In order to do this you simple include `[locale]` inside your directory file path.
 
@@ -447,6 +455,34 @@ module.exports = {
     ],
 };
 ```
+
+##### <u>**Static Content Options**</u>
+
+The recommended setup for Contentful Hugo is to have your content (usually `./content`) and data (usually `./data`) directories ignored in version control. This is because contentful-hugo will generate these directories at build time. However, this creates trouble for instances where you have pages that are not managed in Contentful and aren't generated at build time by another source.
+
+To deal with this problem Contentful-Hugo has a `staticContent` parameter. This paramter accepts an input directory (`inputDir`) that can be commited to git, and an output directory (`outputDir`) which would be your standard content or data directory. All items in the inputDir will get copied into the outputDir at build time and will retain their folder structure.abs
+
+For example in the config below `./static_content/posts/my-post.md` will get copied to `./content/posts/my-post.md`, and `./static_data/global-settings.yaml` will be copied to `./data/global-settings.yaml`.
+
+```js
+module.exports = {
+    // rest of config
+    staticContent: [
+        {
+            // all items in ./static_content will be copied to ./content
+            inputDir: 'static_content',
+            outputDir: 'content',
+        },
+        {
+            // all items in ./static_data will be copied to ./data
+            inputDir: 'static_data',
+            outputDir: 'data',
+        },
+    ],
+};
+```
+
+Contentful-Hugo will also watch for file changes in the inputDir's while running in server mode.
 
 #### Advanced Config Examples
 

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -89,6 +89,10 @@ const endsWith = (str: string | undefined | null, ext: string): boolean => {
     return new RegExp(`${ext}$`).test(str || '');
 };
 
+const replaceBackslashesWithForwardSlashes = (input: string): string => {
+    return input.replace(/\\/g, '/');
+};
+
 export {
     characterIsWhiteSpace,
     isMultilineString,
@@ -98,4 +102,5 @@ export {
     leadingSpaces,
     trailingSpaces,
     endsWith,
+    replaceBackslashesWithForwardSlashes,
 };

--- a/src/main/clean.ts
+++ b/src/main/clean.ts
@@ -1,0 +1,39 @@
+import { remove } from 'fs-extra';
+import { removeLeadingAndTrailingSlashes } from '@helpers/strings';
+import { ContentfulHugoConfig } from './config';
+
+const cleanDirectories = async (
+    config: ContentfulHugoConfig
+): Promise<void> => {
+    const dirs: string[] = ['.contentful-hugo'];
+
+    const getRootDir = (directory: string): string => {
+        const dir = removeLeadingAndTrailingSlashes(
+            directory.replace('./', '')
+        );
+        const dirParts = dir.split('/');
+        return dirParts[0];
+    };
+
+    for (const item of config.singleTypes) {
+        const newDir = getRootDir(item.directory);
+        if (!dirs.includes(newDir)) {
+            dirs.push(newDir);
+        }
+    }
+
+    for (const item of config.repeatableTypes) {
+        const newDir = getRootDir(item.directory);
+        if (!dirs.includes(newDir)) {
+            dirs.push(newDir);
+        }
+    }
+
+    const tasks: Promise<void>[] = [];
+    for (const dir of dirs) {
+        tasks.push(remove(dir));
+    }
+    await Promise.all(tasks);
+};
+
+export default cleanDirectories;

--- a/src/main/config/fileLoader.ts
+++ b/src/main/config/fileLoader.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 import { pathExists, readFile } from 'fs-extra';
 import yaml from 'js-yaml';
-import { determineFileType, isContentfulConfig } from './utilities';
-import { ContentfulConfig } from './types';
+import { determineFileType, isContentfulHugoConfig } from './utilities';
+import { ContentfulHugoConfig } from './types';
 
 const checkContentfulSettings = (config: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
-}): ContentfulConfig => {
+}): ContentfulHugoConfig => {
     let { contentful } = config;
     if (!contentful) {
         contentful = {};
@@ -17,7 +17,7 @@ const checkContentfulSettings = (config: {
     const previewToken =
         contentful.previewToken || process.env.CONTENTFUL_PREVIEW_TOKEN || '';
     const environment = contentful.environment || 'master';
-    const newConfig: ContentfulConfig = {
+    const newConfig: ContentfulHugoConfig = {
         locales: config.locales || [],
         contentful: {
             space,
@@ -27,18 +27,19 @@ const checkContentfulSettings = (config: {
         },
         singleTypes: config.singleTypes || [],
         repeatableTypes: config.repeatableTypes || [],
+        staticContent: config.staticContent || [],
     };
     return newConfig;
 };
 
 const loadJavascriptConfigFile = (
     filePath: string
-): ContentfulConfig | false => {
+): ContentfulHugoConfig | false => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     let configObject = require(filePath);
     if (configObject && typeof configObject === 'object') {
         configObject = checkContentfulSettings(configObject);
-        if (isContentfulConfig(configObject)) {
+        if (isContentfulHugoConfig(configObject)) {
             return configObject;
         }
     }
@@ -47,11 +48,11 @@ const loadJavascriptConfigFile = (
 
 const loadYamlConfigFile = async (
     filePath: string
-): Promise<ContentfulConfig | false> => {
+): Promise<ContentfulHugoConfig | false> => {
     let configObject = yaml.load(await readFile(filePath).toString());
     if (configObject && typeof configObject === 'object') {
         configObject = checkContentfulSettings(configObject);
-        if (isContentfulConfig(configObject)) {
+        if (isContentfulHugoConfig(configObject)) {
             return configObject;
         }
     }
@@ -64,7 +65,7 @@ const loadYamlConfigFile = async (
 const loadFile = async (
     rootDir = '.',
     fileName: string
-): Promise<ContentfulConfig | false> => {
+): Promise<ContentfulHugoConfig | false> => {
     const filePath = path.resolve(rootDir, fileName);
     if (await pathExists(filePath)) {
         const fileType = determineFileType(fileName);

--- a/src/main/config/index.ts
+++ b/src/main/config/index.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { loadFile, checkContentfulSettings } from './fileLoader';
-import { ContentfulConfig, ResolveEntryConfig } from './types';
+import { ContentfulHugoConfig, ResolveEntryConfig } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
@@ -17,7 +17,7 @@ const loadConfig = async (
      * Config filename with extension.
      */
     fileName: string | null = null
-): Promise<ContentfulConfig | false> => {
+): Promise<ContentfulHugoConfig | false> => {
     rootDir = path.resolve(rootDir);
     if (fileName) {
         const result = await loadFile(rootDir, fileName);
@@ -34,7 +34,7 @@ const loadConfig = async (
         'contentful-settings.yaml',
     ];
     const tasks = [];
-    const configList: ContentfulConfig[] = [];
+    const configList: ContentfulHugoConfig[] = [];
     for (const config of defaultConfigs) {
         const file = loadFile(rootDir, config).then((result) => {
             if (result) {
@@ -56,6 +56,6 @@ const loadConfig = async (
 export {
     loadConfig,
     checkContentfulSettings,
-    ContentfulConfig,
+    ContentfulHugoConfig,
     ResolveEntryConfig,
 };

--- a/src/main/config/types.ts
+++ b/src/main/config/types.ts
@@ -97,9 +97,15 @@ export type LocaleConfig = {
     mapTo: string;
 };
 
-export interface ContentfulConfig {
+export type StaticContentConfig = {
+    inputDir: string;
+    outputDir: string;
+};
+
+export interface ContentfulHugoConfig {
     locales: (string | LocaleConfig)[];
     contentful: ConfigContentfulSettings;
     singleTypes: SingleTypeConfig[];
     repeatableTypes: RepeatableTypeConfig[];
+    staticContent: StaticContentConfig[];
 }

--- a/src/main/config/utilities.test.ts
+++ b/src/main/config/utilities.test.ts
@@ -1,6 +1,6 @@
 import {
     determineFileType,
-    isContentfulConfig,
+    isContentfulHugoConfig,
     isValidFileExtension,
 } from './utilities';
 
@@ -46,16 +46,16 @@ describe('Validate fileExtension checks', () => {
 
 describe('Contentful Config Checker', () => {
     test('Should Fail', () => {
-        expect(isContentfulConfig({ somekey: 'somestring' })).toBe(false);
+        expect(isContentfulHugoConfig({ somekey: 'somestring' })).toBe(false);
         expect(
-            isContentfulConfig({
+            isContentfulHugoConfig({
                 contentful: null,
                 singleTypes: [],
                 repeatableTypes: [],
             })
         ).toBe(false);
         expect(
-            isContentfulConfig({
+            isContentfulHugoConfig({
                 contentful: {
                     space: 'myspace',
                     token: 'my-token',
@@ -82,6 +82,6 @@ describe('Contentful Config Checker', () => {
             singleTypes: [],
             repeatableTypes: [],
         };
-        expect(isContentfulConfig(config)).toBe(true);
+        expect(isContentfulHugoConfig(config)).toBe(true);
     });
 });

--- a/src/main/config/utilities.ts
+++ b/src/main/config/utilities.ts
@@ -1,5 +1,5 @@
 import { endsWith } from '@/helpers/strings';
-import { ContentfulConfig, TypeConfig } from './types';
+import { ContentfulHugoConfig, TypeConfig } from './types';
 
 /**
  * Determine if a file is yaml or js depending on the file extension
@@ -40,8 +40,10 @@ const isTypeConfig = (input: unknown): input is TypeConfig[] => {
     return true;
 };
 
-const isContentfulConfig = (input: unknown): input is ContentfulConfig => {
-    const mappedInput = input as ContentfulConfig;
+const isContentfulHugoConfig = (
+    input: unknown
+): input is ContentfulHugoConfig => {
+    const mappedInput = input as ContentfulHugoConfig;
     const { contentful, singleTypes, repeatableTypes } = mappedInput;
     if (!contentful) {
         return false;
@@ -62,4 +64,4 @@ const isContentfulConfig = (input: unknown): input is ContentfulConfig => {
     return true;
 };
 
-export { determineFileType, isContentfulConfig, isValidFileExtension };
+export { determineFileType, isContentfulHugoConfig, isValidFileExtension };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { loadConfig, ContentfulConfig } from './config';
+import { loadConfig, ContentfulHugoConfig } from './config';
 import {
     ConfigContentfulSettings,
     LocaleConfig,
@@ -86,7 +86,7 @@ const fetchType = (
         });
 };
 
-const configCheck = (config: ContentfulConfig) => {
+const configCheck = (config: ContentfulHugoConfig) => {
     const { space, token, environment } = config.contentful;
     const missingParams: string[] = [];
     if (!space) {
@@ -122,7 +122,7 @@ const fetchDataFromContentful = async (
     /**
      * Contentful Hugo Config Object
      */
-    config: ContentfulConfig,
+    config: ContentfulHugoConfig,
     /**
      * Fetch from the Content Preview API
      */
@@ -274,5 +274,5 @@ export {
     fetchDataFromContentful,
     loadConfig,
     initializeDirectory,
-    ContentfulConfig as ContentfulHugoConfig,
+    ContentfulHugoConfig,
 };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import getContentType from './getContentType';
 import getContentTypeResultMessage from './getContentTypeResultMessage';
 import initializeDirectory from './initializeDirectory';
 import { isValidFileExtension } from './config/utilities';
+import { copyStaticContent } from './staticContent/fileManager';
 
 import Limiter = require('async-limiter');
 
@@ -274,5 +275,6 @@ export {
     fetchDataFromContentful,
     loadConfig,
     initializeDirectory,
+    copyStaticContent,
     ContentfulHugoConfig,
 };

--- a/src/main/staticContent/fileManager.ts
+++ b/src/main/staticContent/fileManager.ts
@@ -1,4 +1,4 @@
-import { copyFile, unlink, copy, ensureDir } from 'fs-extra';
+import { copyFile, unlink, copy, ensureDir, ensureFile } from 'fs-extra';
 import path from 'path';
 import { removeLeadingAndTrailingSlashes } from '@helpers/strings';
 import { ContentfulHugoConfig } from '../config';
@@ -12,13 +12,14 @@ export const cleanInputAndOutput = (inputDir: string, outputDir: string) => {
     };
 };
 
-export const copyFileToOutputDirectory = (
+export const copyFileToOutputDirectory = async (
     filePath: string,
     inputDir: string,
     outputDir: string
 ): Promise<void> => {
     const { input, output } = cleanInputAndOutput(inputDir, outputDir);
     const newFilePath = filePath.replace(`${input}/`, `${output}/`);
+    await ensureFile(newFilePath);
     return copyFile(filePath, newFilePath);
 };
 

--- a/src/main/staticContent/fileManager.ts
+++ b/src/main/staticContent/fileManager.ts
@@ -1,4 +1,4 @@
-import { copyFile, unlink, copy } from 'fs-extra';
+import { copyFile, unlink, copy, ensureDir } from 'fs-extra';
 import path from 'path';
 import { removeLeadingAndTrailingSlashes } from '@helpers/strings';
 import { ContentfulHugoConfig } from '../config';
@@ -32,10 +32,11 @@ export const deleteFileFromOutputDirectory = (
     return unlink(newFilePath);
 };
 
-export const copyInputDirectoryToOutputDirectory = (
+export const copyInputDirectoryToOutputDirectory = async (
     inputDir: string,
     outputDir: string
 ): Promise<void> => {
+    await ensureDir(inputDir);
     const srcPath = path.resolve(inputDir);
     const outPath = path.resolve(outputDir);
     return copy(srcPath, outPath);

--- a/src/main/staticContent/fileManager.ts
+++ b/src/main/staticContent/fileManager.ts
@@ -1,0 +1,56 @@
+import { copyFile, unlink, copy } from 'fs-extra';
+import path from 'path';
+import { removeLeadingAndTrailingSlashes } from '@helpers/strings';
+import { ContentfulHugoConfig } from '../config';
+
+export const cleanInputAndOutput = (inputDir: string, outputDir: string) => {
+    const input = removeLeadingAndTrailingSlashes(inputDir.replace('./', ''));
+    const output = removeLeadingAndTrailingSlashes(outputDir.replace('./', ''));
+    return {
+        input,
+        output,
+    };
+};
+
+export const copyFileToOutputDirectory = (
+    filePath: string,
+    inputDir: string,
+    outputDir: string
+): Promise<void> => {
+    const { input, output } = cleanInputAndOutput(inputDir, outputDir);
+    const newFilePath = filePath.replace(`${input}/`, `${output}/`);
+    return copyFile(filePath, newFilePath);
+};
+
+export const deleteFileFromOutputDirectory = (
+    filePath: string,
+    inputDir: string,
+    outputDir: string
+): Promise<void> => {
+    const { input, output } = cleanInputAndOutput(inputDir, outputDir);
+    const newFilePath = filePath.replace(`${input}/`, `${output}/`);
+    return unlink(newFilePath);
+};
+
+export const copyInputDirectoryToOutputDirectory = (
+    inputDir: string,
+    outputDir: string
+): Promise<void> => {
+    const srcPath = path.resolve(inputDir);
+    const outPath = path.resolve(outputDir);
+    return copy(srcPath, outPath);
+};
+
+export const copyStaticContent = async (
+    config: ContentfulHugoConfig
+): Promise<void> => {
+    if (!config.staticContent || !config.staticContent.length) {
+        return;
+    }
+    const tasks: Promise<void>[] = [];
+    for (const item of config.staticContent) {
+        const { inputDir, outputDir } = item;
+        tasks.push(copyInputDirectoryToOutputDirectory(inputDir, outputDir));
+    }
+    await Promise.all(tasks);
+};

--- a/src/main/staticContent/fileManager.ts
+++ b/src/main/staticContent/fileManager.ts
@@ -3,7 +3,10 @@ import path from 'path';
 import { removeLeadingAndTrailingSlashes } from '@helpers/strings';
 import { ContentfulHugoConfig } from '../config';
 
-export const cleanInputAndOutput = (inputDir: string, outputDir: string) => {
+export const cleanInputAndOutput = (
+    inputDir: string,
+    outputDir: string
+): { input: string; output: string } => {
     const input = removeLeadingAndTrailingSlashes(inputDir.replace('./', ''));
     const output = removeLeadingAndTrailingSlashes(outputDir.replace('./', ''));
     return {

--- a/src/main/staticContent/watcher.ts
+++ b/src/main/staticContent/watcher.ts
@@ -5,7 +5,10 @@ import {
     deleteFileFromOutputDirectory,
 } from './fileManager';
 import { ContentfulHugoConfig } from '../config';
-import { removeLeadingAndTrailingSlashes } from '@helpers/strings';
+import {
+    removeLeadingAndTrailingSlashes,
+    replaceBackslashesWithForwardSlashes,
+} from '@helpers/strings';
 
 const createWatcher = (config: ContentfulHugoConfig): void => {
     if (!config.singleTypes || !config.staticContent.length) {
@@ -24,7 +27,7 @@ const createWatcher = (config: ContentfulHugoConfig): void => {
 
     const getRootDir = (path: string) => {
         const filePath = removeLeadingAndTrailingSlashes(path);
-        const pathParts = filePath.split('\\');
+        const pathParts = filePath.split('/');
         return pathParts[0];
     };
     const handleCopy = (path: string) => {
@@ -45,18 +48,20 @@ const createWatcher = (config: ContentfulHugoConfig): void => {
         return deleteFileFromOutputDirectory(path, rootDir, outDir);
     };
 
-    const watcher = chokidar.watch(watchPaths);
+    const watcher = chokidar.watch(watchPaths, {
+        persistent: true,
+    });
     watcher.on('add', (path) => {
         console.log(`[contentful hugo] ${path} added`);
-        return handleCopy(path);
+        return handleCopy(replaceBackslashesWithForwardSlashes(path));
     });
     watcher.on('change', (path) => {
         console.log(`[contentful hugo] ${path} changed`);
-        return handleCopy(path);
+        return handleCopy(replaceBackslashesWithForwardSlashes(path));
     });
     watcher.on('unlink', (path) => {
         console.log(`[contentful hugo] ${path} deleted`);
-        return handleDelete(path);
+        return handleDelete(replaceBackslashesWithForwardSlashes(path));
     });
 };
 

--- a/src/main/staticContent/watcher.ts
+++ b/src/main/staticContent/watcher.ts
@@ -24,7 +24,7 @@ const createWatcher = (config: ContentfulHugoConfig): void => {
 
     const getRootDir = (path: string) => {
         const filePath = removeLeadingAndTrailingSlashes(path);
-        const pathParts = filePath.split('/');
+        const pathParts = filePath.split('\\');
         return pathParts[0];
     };
     const handleCopy = (path: string) => {

--- a/src/main/staticContent/watcher.ts
+++ b/src/main/staticContent/watcher.ts
@@ -1,0 +1,63 @@
+import chokidar from 'chokidar';
+import {
+    cleanInputAndOutput,
+    copyFileToOutputDirectory,
+    deleteFileFromOutputDirectory,
+} from './fileManager';
+import { ContentfulHugoConfig } from '../config';
+import { removeLeadingAndTrailingSlashes } from '@helpers/strings';
+
+const createWatcher = (config: ContentfulHugoConfig): void => {
+    if (!config.singleTypes || !config.staticContent.length) {
+        return;
+    }
+    const directoryMap: { [key: string]: string } = {};
+    const watchPaths: string[] = [];
+    for (const item of config.staticContent) {
+        const { input, output } = cleanInputAndOutput(
+            item.inputDir,
+            item.outputDir
+        );
+        watchPaths.push(input);
+        directoryMap[input] = output;
+    }
+
+    const getRootDir = (path: string) => {
+        const filePath = removeLeadingAndTrailingSlashes(path);
+        const pathParts = filePath.split('/');
+        return pathParts[0];
+    };
+    const handleCopy = (path: string) => {
+        const rootDir = getRootDir(path);
+        const outDir = directoryMap[rootDir];
+        if (!outDir) {
+            return;
+        }
+        return copyFileToOutputDirectory(path, rootDir, outDir);
+    };
+
+    const handleDelete = (path: string) => {
+        const rootDir = getRootDir(path);
+        const outDir = directoryMap[rootDir];
+        if (!outDir) {
+            return;
+        }
+        return deleteFileFromOutputDirectory(path, rootDir, outDir);
+    };
+
+    const watcher = chokidar.watch(watchPaths);
+    watcher.on('add', (path) => {
+        console.log(`[contentful hugo] ${path} added`);
+        return handleCopy(path);
+    });
+    watcher.on('change', (path) => {
+        console.log(`[contentful hugo] ${path} changed`);
+        return handleCopy(path);
+    });
+    watcher.on('unlink', (path) => {
+        console.log(`[contentful hugo] ${path} deleted`);
+        return handleDelete(path);
+    });
+};
+
+export default createWatcher;

--- a/src/server/deleteFile.ts
+++ b/src/server/deleteFile.ts
@@ -12,7 +12,7 @@ const deleteFile = async (
     if (await pathExists(path)) {
         await unlink(path);
         if (!quietMode) {
-            console.log(`deleted ${path}`);
+            console.log(`[contentful hugo] deleted ${path}`);
         }
     }
     return null;

--- a/src/server/determineFileLocation.test.ts
+++ b/src/server/determineFileLocation.test.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import { ensureDir, unlink, writeFile } from 'fs-extra';
-import { ContentfulConfig } from '../main/config/types';
+import { ContentfulHugoConfig } from '../main/config/types';
 import determineFileLocations from './determineFileLocation';
 
 const YAML = require('json-to-pretty-yaml');
 
-const testConfig: ContentfulConfig = {
+const testConfig: ContentfulHugoConfig = {
     locales: [],
     contentful: {
         space: '',
@@ -57,6 +57,7 @@ const testConfig: ContentfulConfig = {
             fileExtension: 'md',
         },
     ],
+    staticContent: [],
 };
 
 const testEntryId = 'my-test-entry-id';

--- a/src/server/fetchEntryFromContentful.ts
+++ b/src/server/fetchEntryFromContentful.ts
@@ -17,7 +17,7 @@ const fetchEntryFromContentful = async (
     );
     const tasks = [];
     for (const cf of configs) {
-        const contentSettings: ContentSettings = {
+        const contentSettings = {
             typeId: cf.typeId,
             directory: cf.directory,
             fileExtension: cf.fileExtension,
@@ -31,9 +31,10 @@ const fetchEntryFromContentful = async (
             resolveEntries: cf.resolveEntries,
             overrides: cf.overrides,
             mainContent: cf.mainContent,
-            filters: { 'sys.id': entryId },
+            filters: cf.filters || {},
             locale: cf.locale,
         };
+        contentSettings.filters['sys.id'] = entryId;
         const contentfulSettings: ConfigContentfulSettings = config.contentful;
         tasks.push(
             getContentType(

--- a/src/server/handleEntry.ts
+++ b/src/server/handleEntry.ts
@@ -27,7 +27,7 @@ const updateEntry = (
                 false
             );
             for (const location of fileLocations) {
-                console.log(`created ${resolve(location)}`);
+                console.log(`[contentful hugo] created ${resolve(location)}`);
             }
             const message = `Created ${fileLocations.length} file${
                 fileLocations.length === 1 ? '' : 's'

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import express, { Response } from 'express';
-import { IncomingHttpHeaders, Server } from 'http';
+import { IncomingHttpHeaders } from 'http';
 import { Entry, Asset, ContentType } from 'contentful';
 import { ContentfulHugoConfig } from '@main/index';
 import { removeEntry, updateEntry } from './handleEntry';
+import createWatcher from '@/main/staticContent/watcher';
 
 const app = express();
 app.use(express.urlencoded({ extended: true }));
@@ -99,7 +100,7 @@ const startServer = (
     config: ContentfulHugoConfig,
     port = 1414,
     previewMode = false
-): Server => {
+): void => {
     if (!config) {
         throw new Error('Missing contentful hugo config');
     }
@@ -164,9 +165,13 @@ const startServer = (
         });
     });
 
-    return app.listen(port, () => {
-        console.log(`server started at http://localhost:${port}`);
+    app.listen(port, () => {
+        console.log(
+            `[contentful hugo] server started at http://localhost:${port}`
+        );
     });
+
+    createWatcher(config);
 };
 
 export default startServer;


### PR DESCRIPTION
## Static Content

In a typical setup, `content` and `data` directories get added to `.gitignore`. This is because Contentful is being used to generate all the content at build time. However this makes it awkward when you have content that is not managed by Contentful. For example you might have some global data files or a contact page that you don't want editors to mess with. 

You could put the files in the `./content` and `./data` directories and then add exceptions for them in the git ignore folder but it makes cleaning those folders very tedious as you can't delete the whole directory or you'll delete those files as well.

This feature solves that problem by allowing you to specify "static content" directories. 

```js
// contentful-hugo.config.js
module.exports = {
  // rest of config
  staticContent = [
     {
        inputDir: "static_content",
        ouputDir: "content"
      },
      {
        inputDir: "static_data",
        outputDir: "data"
      }
  ]
}
```

The files in these directories will be copied into your content directories at build time along with the Contentful data, and when running with the `--server` flag contentful-hugo will watch for changes in the inputDirectory and copy any changes that are made in real time. This addition makes cleaning your content and data directories super easy since now you have a separate designated folder for static content. Which leads to the next feature addition in this PR.

## Contentful-Hugo --clean

A `--clean` flag has been added. So now when you run `contentful-hugo --clean` it will look in your config for any output directories and delete them all. Along with any other temp files that contentful-hugo generates such as the `./.contentful-hugo` directory