### PR TITLE
feat: configure number entries to fetch per request

### DIFF
--- a/src/main/config/fileLoader.ts
+++ b/src/main/config/fileLoader.ts
@@ -25,6 +25,7 @@ export const checkContentfulSettings = (config: {
             token,
             previewToken,
             environment,
+            pageSize: contentful.pageSize,
         },
         singleTypes: config.singleTypes || [],
         repeatableTypes: config.repeatableTypes || [],

--- a/src/main/config/types.ts
+++ b/src/main/config/types.ts
@@ -103,6 +103,12 @@ export interface ConfigContentfulSettings {
      * Contentful environment ID
      */
     environment: string;
+
+    /**
+     * Number of entries to fetch per request.
+     * Defaults to 1000
+     */
+    pageSize?: number;
 }
 
 export type LocaleConfig = {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -200,6 +200,7 @@ const fetchDataFromContentful = async (
             };
         }
         if (isValidFileExtension(settings.fileExtension)) {
+            const pageSize: number = config.contentful.pageSize ? config.contentful.pageSize : 1000;
             if (config.locales.length && !item.ignoreLocales) {
                 // add a job for each locale
                 for (const locale of config.locales) {
@@ -213,7 +214,7 @@ const fetchDataFromContentful = async (
                         newSettings.locale = locale;
                     }
                     const job = {
-                        limit: isSingle ? 1 : 1000,
+                        limit: isSingle ? 1 : pageSize,
                         skip: 0,
                         contentSettings: newSettings,
                         isPreview,
@@ -223,7 +224,7 @@ const fetchDataFromContentful = async (
             } else {
                 // add single job if no locales
                 const job = {
-                    limit: isSingle ? 1 : 1000,
+                    limit: isSingle ? 1 : pageSize,
                     skip: 0,
                     contentSettings: settings,
                     isPreview,


### PR DESCRIPTION
First of all thank you for all the great work and sharing it with the world 🙌 

We were facing following issue when fetching content:
```json
{
  "status": 400,
  "statusText": "Bad Request",
  "message": "Response size too big. Maximum allowed response size: 7340032B.",
  "details": {},
  "request": {
    "url": "https://cdn.contentful.com:443/spaces/REDACTED/environments/master/entries",
    "headers": {
      "Accept": "application/json, text/plain, */*",
      "Content-Type": "application/vnd.contentful.delivery.v1+json",
      "X-Contentful-User-Agent": "sdk contentful.js/11.5.2; platform node.js/v23.7.0; os macOS/v23.7.0;",
      "Authorization": "Bearer ...NgKcg",
      "User-Agent": "axios/1.8.1",
      "Accept-Encoding": "gzip, compress, deflate, br"
    },
    "method": "get"
  },
  "requestId": "REDACTED"
}
```

Contentful enforces a 7MB limit per response.
We have 300+ long blog posts. We would need to fetch fewer entries per request.

Here is a simple proposal to allow consumer to configure how many entries to fetch per request.
Default is still 1000 and it does not introduce any breaking changes.
I'm open to change naming etc.

Alternative approach could implement back-off based on the server response but I though it might get unnecessarily complicated and would require extensive test coverage.
