### PR TITLE
make all config.contentful fields optional in config file

### DIFF
--- a/src/main/config/index.ts
+++ b/src/main/config/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import dotenv from 'dotenv';
 import { loadFile, checkContentfulSettings } from './fileLoader';
-import type { ContentfulHugoConfig } from './types';
+import type { ConfigContentfulSettings, ContentfulHugoConfig } from './types';
 
 export * from './types';
 
@@ -59,4 +59,8 @@ export const loadConfig = async (
     return false;
 };
 
-export const defineConfig = (config: Partial<ContentfulHugoConfig>) => config;
+export const defineConfig = (
+    config: Partial<Omit<ContentfulHugoConfig, 'contentful'>> & {
+        contentful: Partial<ConfigContentfulSettings>;
+    }
+) => config;


### PR DESCRIPTION
This is QoL change that makes defining a config easier. Default behavior of using environment variables by default still exists so this should be non-breaking.

This basically makes it easier to set the `pageSize` parameter without having to set all of the other contentful fields (if you already have environment variables set)

```ts
export default defineConfig({
  contentful: {
    pageSize: 15, // typescript no longer complains that `space`, `token`, and `environment` are missing
  }
})
```